### PR TITLE
update the correct version

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate Pages
         run: bash .github/scripts/generatehtml.sh
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
I accidentally updated this action thinking it was "artifact uploader" before, not "upload pages artifacts". I think this is the correct "lastest" version now.