### PR TITLE
revert upload pages artifact to v1

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate Pages
         run: bash .github/scripts/generatehtml.sh
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
Need to figure out how to get upload-pages-artifacts V3 to work properly. For now we will just use V1. We might not even need the plugin, we already have the static content we need. We should look at what the action actually does as well, and write an alternative if it's extremely simple (I think it will be).