### PR TITLE
image fills top to bottom of page margins on sides

### DIFF
--- a/custom_css/main.css
+++ b/custom_css/main.css
@@ -1,5 +1,9 @@
-@media only screen and (max-width: 600px)  {
-  img{
-    width: 100%
-  }
+img {
+  display: block;
+  height: 100vh;
+  object-fit: cover;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
 }
+


### PR DESCRIPTION
This properly fills images in a page vertically. It leaves margins on the left and right, and allows the image to be properly centered.
OLD:
<img width="1278" height="721" alt="Screenshot 2025-09-26 at 4 36 09 PM" src="https://github.com/user-attachments/assets/35152673-0026-4d49-97f1-e1377592ad11" />
NEW:
<img width="1278" height="721" alt="Screenshot 2025-09-26 at 4 36 21 PM" src="https://github.com/user-attachments/assets/2133b091-1d79-44a3-9f9b-eb38c59e1fdb" />
