### PR TITLE
upgrade artifact upload to v4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate Pages
         run: bash .github/scripts/generatehtml.sh
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
upload pages artifact v1 is long deprecated, so we are upgrading to V4.