### PR TITLE
remove white margin around index

### DIFF
--- a/custom_css/page_index.css
+++ b/custom_css/page_index.css
@@ -1,6 +1,6 @@
 /* TODO: right side of list is misaligned with search bar */
 * {
-    /*background-color:#2d2a2a;*/
+    margin: 0;
   }
 
   #main {


### PR DESCRIPTION
This removes the small white margin around the page index.

before:
<img width="1278" height="667" alt="Screenshot 2025-09-26 at 5 26 13 PM" src="https://github.com/user-attachments/assets/7854a96b-495a-4c85-81b0-b4f5dbcc967f" />
after:
<img width="1278" height="667" alt="Screenshot 2025-09-26 at 5 26 38 PM" src="https://github.com/user-attachments/assets/5d357149-c9cd-415b-b636-f8b642aacdab" />
