### PR TITLE
add div after 4 links instead of 3 now that latest link is gone

### DIFF
--- a/.github/scripts/generatehtml.sh
+++ b/.github/scripts/generatehtml.sh
@@ -47,7 +47,7 @@ for file in $(ls -r [0-9]*.html [0-9]*.link 2>/dev/null); do
   fi
 
   count=$((count+1))
-  if [ "$count" -eq 3 ]; then
+  if [ "$count" -eq 4 ]; then
     echo "<div class=\"window-gap\"></div>" >> $target_file
   fi
 done


### PR DESCRIPTION
The last PR broke page formatting because removing the "latest" link changed the link count by one. This attempts to fix that.

Last broken PR:
https://github.com/source-butcher/butche.red/pull/46

Original Issue:
https://github.com/source-butcher/butche.red/issues/45